### PR TITLE
Update Go version for Cloud Functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ gcloud functions deploy YOUR_FUNCTION_NAME \
 --entry-point=ReportAlertToTeams \
 --memory=256MB \
 --region=YOUR_REGION \
---runtime=go118 \
+--runtime=go121 \
 --trigger-topic=YOUR_PUBSUB_TOPIC_NAME \
 --min-instances 0 \
 --max-instances 3 \ 

--- a/function.go
+++ b/function.go
@@ -2,9 +2,9 @@ package function
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
-	"context"
 	"log"
 	"net/http"
 	"net/url"
@@ -153,7 +153,7 @@ type PubSubMessage struct {
 	Data []byte `json:"data"`
 }
 
-func ReportAlertToTeams(ctx context.Context, m PubSubMessage) error{
+func ReportAlertToTeams(ctx context.Context, m PubSubMessage) error {
 
 	log.Println(string(m.Data))
 
@@ -161,7 +161,6 @@ func ReportAlertToTeams(ctx context.Context, m PubSubMessage) error{
 	if teamsWebhookURL == "" {
 		log.Fatalln("`TEAMS_WEBHOOK_URL` is not set in the environments")
 	}
-
 
 	if _, err := url.Parse(teamsWebhookURL); err != nil {
 		log.Fatalln(err)
@@ -190,5 +189,5 @@ func ReportAlertToTeams(ctx context.Context, m PubSubMessage) error{
 		log.Fatalln("unexpected status code", res.StatusCode)
 	}
 	return nil
-	
+
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/foward/gcp-monitoring-to-msteams
 
-go 1.18
+go 1.21
 
 require github.com/dustin/go-humanize v1.0.0


### PR DESCRIPTION
Go 1.18 was deprecated in Cloud Functions

https://cloud.google.com/functions/docs/runtime-support#go